### PR TITLE
First attempt at CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: chriz2600/quartus-lite:latest
+    working_directory: /build
+    steps:
+      - checkout
+      - run: /usr/local/bin/quartus_wrapper "quartus_sh --flow compile SMS-lite.qsf"
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build


### PR DESCRIPTION
This makes sure that whatever is in the PR will actually build in Quartus. 

Please keep in mind that the CI build is using the lite project, not the full, as the docker container used for the build only has quartus-lite for licensing reasons. 