### PR TITLE
added small testbench to PSG

### DIFF
--- a/SMS-lite.qsf
+++ b/SMS-lite.qsf
@@ -29,7 +29,7 @@ set_global_assignment -name FAMILY "Cyclone V"
 set_global_assignment -name DEVICE 5CSEBA6U23I7
 set_global_assignment -name TOP_LEVEL_ENTITY sys_top
 set_global_assignment -name ORIGINAL_QUARTUS_VERSION 16.1.2
-set_global_assignment -name LAST_QUARTUS_VERSION "17.0.1 Standard Edition"
+set_global_assignment -name LAST_QUARTUS_VERSION "17.0.0 Lite Edition"
 set_global_assignment -name PROJECT_CREATION_TIME_DATE "01:53:30  APRIL 20, 2017"
 set_global_assignment -name DEVICE_FILTER_PACKAGE UFBGA
 set_global_assignment -name DEVICE_FILTER_PIN_COUNT 672

--- a/SMS.qpf
+++ b/SMS.qpf
@@ -1,13 +1,32 @@
+# -------------------------------------------------------------------------- #
 #
-# please keep this file read-only!
-# Quartus changes this file everytime revision is switched, 
-# and it will be marked as changed with every commit.
+# Copyright (C) 2017  Intel Corporation. All rights reserved.
+# Your use of Intel Corporation's design tools, logic functions 
+# and other software and tools, and its AMPP partner logic 
+# functions, and any output files from any of the foregoing 
+# (including device programming or simulation files), and any 
+# associated documentation or information are expressly subject 
+# to the terms and conditions of the Intel Program License 
+# Subscription Agreement, the Intel Quartus Prime License Agreement,
+# the Intel MegaCore Function License Agreement, or other 
+# applicable license agreement, including, without limitation, 
+# that your use is for the sole purpose of programming logic 
+# devices manufactured by Intel and sold by Intel or its 
+# authorized distributors.  Please refer to the applicable 
+# agreement for further details.
 #
+# -------------------------------------------------------------------------- #
+#
+# Quartus Prime
+# Version 17.0.0 Build 595 04/25/2017 SJ Lite Edition
+# Date created = 11:56:43  October 19, 2018
+#
+# -------------------------------------------------------------------------- #
 
-QUARTUS_VERSION = "16.1"
-DATE = "23:13:02  April 27, 2017"
+QUARTUS_VERSION = "17.0"
+DATE = "11:56:43  October 19, 2018"
 
 # Revisions
 
-PROJECT_REVISION = "SMS"
 PROJECT_REVISION = "SMS-lite"
+PROJECT_REVISION = "SMS"

--- a/SMS.qsf
+++ b/SMS.qsf
@@ -27,7 +27,7 @@ set_global_assignment -name FAMILY "Cyclone V"
 set_global_assignment -name DEVICE 5CSEBA6U23I7
 set_global_assignment -name TOP_LEVEL_ENTITY sys_top
 set_global_assignment -name ORIGINAL_QUARTUS_VERSION 16.1.2
-set_global_assignment -name LAST_QUARTUS_VERSION "17.0.1 Standard Edition"
+set_global_assignment -name LAST_QUARTUS_VERSION "17.0.0 Lite Edition"
 set_global_assignment -name PROJECT_CREATION_TIME_DATE "01:53:30  APRIL 20, 2017"
 set_global_assignment -name DEVICE_FILTER_PACKAGE UFBGA
 set_global_assignment -name DEVICE_FILTER_PIN_COUNT 672
@@ -38,9 +38,6 @@ set_global_assignment -name PROJECT_OUTPUT_DIRECTORY output_files
 set_global_assignment -name NUM_PARALLEL_PROCESSORS ALL
 set_global_assignment -name SAVE_DISK_SPACE OFF
 set_global_assignment -name SMART_RECOMPILE ON
-set_global_assignment -name PARTITION_NETLIST_TYPE SOURCE -section_id Top
-set_global_assignment -name PARTITION_FITTER_PRESERVATION_LEVEL PLACEMENT_AND_ROUTING -section_id Top
-set_global_assignment -name PARTITION_COLOR 16764057 -section_id Top
 set_global_assignment -name MIN_CORE_JUNCTION_TEMP "-40"
 set_global_assignment -name MAX_CORE_JUNCTION_TEMP 100
 set_global_assignment -name POWER_PRESET_COOLING_SOLUTION "23 MM HEAT SINK WITH 200 LFPM AIRFLOW"
@@ -380,4 +377,19 @@ set_global_assignment -name VHDL_FILE psg_noise.vhd
 set_global_assignment -name VHDL_FILE psg.vhd
 set_global_assignment -name VHDL_FILE io.vhd
 set_global_assignment -name SYSTEMVERILOG_FILE SMS.sv
+set_global_assignment -name EDA_SIMULATION_TOOL "ModelSim-Altera (VHDL)"
+set_global_assignment -name EDA_TIME_SCALE "1 ps" -section_id eda_simulation
+set_global_assignment -name EDA_OUTPUT_DATA_FORMAT VHDL -section_id eda_simulation
+set_global_assignment -name EDA_TEST_BENCH_ENABLE_STATUS TEST_BENCH_MODE -section_id eda_simulation
+set_global_assignment -name EDA_NATIVELINK_SIMULATION_TEST_BENCH psg_4bit_output_tb -section_id eda_simulation
+set_global_assignment -name VHDL_FILE "testbenches/psg-4bit-output-tb.vhd"
+set_global_assignment -name VHDL_FILE testbenches/psg_4bit_output_tb.vhd
+set_global_assignment -name EDA_TEST_BENCH_NAME psg_4bit_output_tb -section_id eda_simulation
+set_global_assignment -name EDA_DESIGN_INSTANCE_NAME NA -section_id psg_4bit_output_tb
+set_global_assignment -name EDA_TEST_BENCH_RUN_SIM_FOR "50 us" -section_id psg_4bit_output_tb
+set_global_assignment -name EDA_TEST_BENCH_MODULE_NAME psg_4bit_output_tb -section_id psg_4bit_output_tb
+set_global_assignment -name EDA_TEST_BENCH_FILE testbenches/psg_4bit_output_tb.vhd -section_id psg_4bit_output_tb
+set_global_assignment -name PARTITION_NETLIST_TYPE SOURCE -section_id Top
+set_global_assignment -name PARTITION_FITTER_PRESERVATION_LEVEL PLACEMENT_AND_ROUTING -section_id Top
+set_global_assignment -name PARTITION_COLOR 16764057 -section_id Top
 set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top

--- a/testbenches/psg_4bit_output_tb.do
+++ b/testbenches/psg_4bit_output_tb.do
@@ -1,0 +1,38 @@
+onerror {resume}
+quietly WaveActivateNextPane {} 0
+add wave -noupdate /psg_4bit_output_tb/clk_tb
+add wave -noupdate /psg_4bit_output_tb/WR_n_tb
+add wave -noupdate -radix hexadecimal /psg_4bit_output_tb/D_in_tb
+add wave -noupdate -radix hexadecimal -childformat {{/psg_4bit_output_tb/output_tb(5) -radix hexadecimal} {/psg_4bit_output_tb/output_tb(4) -radix hexadecimal} {/psg_4bit_output_tb/output_tb(3) -radix hexadecimal} {/psg_4bit_output_tb/output_tb(2) -radix hexadecimal} {/psg_4bit_output_tb/output_tb(1) -radix hexadecimal} {/psg_4bit_output_tb/output_tb(0) -radix hexadecimal}} -subitemconfig {/psg_4bit_output_tb/output_tb(5) {-height 15 -radix hexadecimal} /psg_4bit_output_tb/output_tb(4) {-height 15 -radix hexadecimal} /psg_4bit_output_tb/output_tb(3) {-height 15 -radix hexadecimal} /psg_4bit_output_tb/output_tb(2) {-height 15 -radix hexadecimal} /psg_4bit_output_tb/output_tb(1) {-height 15 -radix hexadecimal} /psg_4bit_output_tb/output_tb(0) {-height 15 -radix hexadecimal}} /psg_4bit_output_tb/output_tb
+add wave -noupdate /psg_4bit_output_tb/reset_n_tb
+add wave -noupdate -radix hexadecimal /psg_4bit_output_tb/psg_u0/output0
+add wave -noupdate -radix hexadecimal /psg_4bit_output_tb/psg_u0/output1
+add wave -noupdate -radix hexadecimal /psg_4bit_output_tb/psg_u0/output2
+add wave -noupdate -radix hexadecimal /psg_4bit_output_tb/psg_u0/output3
+add wave -noupdate -radix hexadecimal /psg_4bit_output_tb/psg_u0/volume0
+add wave -noupdate -radix hexadecimal /psg_4bit_output_tb/psg_u0/volume1
+add wave -noupdate -radix hexadecimal /psg_4bit_output_tb/psg_u0/volume2
+add wave -noupdate -radix hexadecimal /psg_4bit_output_tb/psg_u0/volume3
+add wave -noupdate -radix hexadecimal /psg_4bit_output_tb/psg_u0/tone0
+add wave -noupdate -radix hexadecimal /psg_4bit_output_tb/psg_u0/tone1
+add wave -noupdate -radix hexadecimal /psg_4bit_output_tb/psg_u0/tone2
+add wave -noupdate -radix hexadecimal /psg_4bit_output_tb/psg_u0/ctrl3
+add wave -noupdate /psg_4bit_output_tb/psg_u0/t0/counter
+TreeUpdate [SetDefaultTree]
+WaveRestoreCursors {{Cursor 1} {2834696 ps} 0}
+quietly wave cursor active 1
+configure wave -namecolwidth 246
+configure wave -valuecolwidth 100
+configure wave -justifyvalue left
+configure wave -signalnamewidth 0
+configure wave -snapdistance 10
+configure wave -datasetprefix 0
+configure wave -rowmargin 4
+configure wave -childrowmargin 2
+configure wave -gridoffset 0
+configure wave -gridperiod 1
+configure wave -griddelta 40
+configure wave -timeline 0
+configure wave -timelineunits ps
+update
+WaveRestoreZoom {0 ps} {12053960 ps}

--- a/testbenches/psg_4bit_output_tb.vhd
+++ b/testbenches/psg_4bit_output_tb.vhd
@@ -1,0 +1,104 @@
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+use IEEE.NUMERIC_STD.ALL;
+
+
+entity psg_4bit_output_tb is
+	-- testbenches have no entity content
+end entity;
+
+architecture tb of psg_4bit_output_tb is
+
+	-- clock period, 279ns would be 3.579545 MHz but 200ns is easier on the eyes
+	-- for alignment in simulation window
+	constant	clk_period	:	time := 200 ns;
+
+	-- sim signals, must match in size and type the entity being tested
+	-- also, initialize inputs
+	signal	clk_tb		:	STD_LOGIC := '0';
+	signal	WR_n_tb		:	STD_LOGIC := '1';
+	signal	D_in_tb		:	STD_LOGIC_VECTOR (7 downto 0) := x"FF";
+	signal	output_tb	:	STD_LOGIC_VECTOR (5 downto 0);
+	signal	reset_n_tb	:	STD_LOGIC := '0';
+	
+	-- procedure for writing to PSG
+	procedure psg_write(
+		constant psg_value	: in	INTEGER;
+		signal 	psg_data		: out	STD_LOGIC_VECTOR (7 downto 0);
+		signal	wr				: out	STD_LOGIC
+		) is
+	begin 
+		psg_data <= std_logic_vector(to_unsigned(psg_value, psg_data'length));
+		wait for clk_period/2;
+		wr <= '0';
+		wait for clk_period;
+		wr <= '1';
+		wait for clk_period/2;
+	end psg_write;
+	
+	
+begin
+
+	-- instantiate the psg for simulation
+	psg_u0	: entity work.psg
+		port map(
+			clk => clk_tb,
+			WR_n => WR_n_tb,
+			D_in => D_in_tb,
+			output => output_tb,
+			reset_n => reset_n_tb
+		);
+
+	-- clock process
+	psg_clk : process is
+	begin
+		clk_tb <= '0';
+		wait for clk_period/2;
+		clk_tb <= '1';
+		wait for clk_period/2;
+	end process;
+	
+	-- simulation process
+	psg_sim : process is
+	begin
+		
+		-- setup initial states
+		WR_n_tb <= '1';
+		D_in_tb <= x"FF";
+		reset_n_tb <= '0';
+		
+		-- hold reset for a while
+		wait for clk_period*5;
+		reset_n_tb <= '1';
+	
+		-- write 0 to all four volume registers using procedure
+		-- hex in constant type is base#value# i.e. 16#FE#
+		-- binary in constant type is same: i.e. 2#10101010#
+		psg_write(2#10010000#, D_in_tb, WR_n_tb);
+		psg_write(2#10110000#, D_in_tb, WR_n_tb);
+		psg_write(2#11010000#, D_in_tb, WR_n_tb);
+		psg_write(2#11110000#, D_in_tb, WR_n_tb);
+	
+	
+		-- wait a bit
+		D_in_tb <= "11111111";
+		wait for clk_period*4;
+		
+		
+		-- write all volume levels to channel 0, not using procedure
+		for volume_val in 0 to 15 loop
+			D_in_tb <= "1001" & std_logic_vector(to_unsigned(volume_val, 4));
+			wait for clk_period/2;
+			WR_n_tb <= '0';
+			wait for clk_period;
+			WR_n_tb <= '1';
+			wait for clk_period/2;
+		end loop;
+		
+		-- simulation loops around until max time is reached, pause a bit here
+		wait for clk_period*10;
+	
+	end process;
+		
+end tb;
+


### PR DESCRIPTION
Testbenches can be run by synthesizing the PSG.vhd as top-level entity (no need to compile the whole core) and then running Modelsim-Altera while pointing to the SMS_MiSTer\simulation\modelsim folder. In there you should be able to compile the psg_4bit_output_tb.vhd and also open the formatting .do file of the same name.