### PR TITLE
Save the build artifacts generated by the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - checkout
       - run: /usr/local/bin/quartus_wrapper "quartus_sh --flow compile SMS-lite.qsf"
+      - store_artifacts:
+        path: /build/output_files
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run: /usr/local/bin/quartus_wrapper "quartus_sh --flow compile SMS-lite.qsf"
       - store_artifacts:
-        path: /build/output_files
+          path: /build/output_files
 
 workflows:
   version: 2


### PR DESCRIPTION
Keep the build artifacts around. Might make it easier to test PR builds, or analyze failures.